### PR TITLE
update distribute_non_work_ixxi.py to import inro.emme.matrix as ematrix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,3 @@ Daysim/last-run.log
 /scripts/supplemental/mode_choice_supplemental.py
 /2019_bike_volums_comparison.xlsx
 /Auto_traffic_validation_bkr0v1-02.xlsx
-/zone_partition
-/multi_run.py
-/multi_run.bat
-/Bellevue_PMA1.txt

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ Daysim/last-run.log
 /scripts/supplemental/mode_choice_supplemental.py
 /2019_bike_volums_comparison.xlsx
 /Auto_traffic_validation_bkr0v1-02.xlsx
+/zone_partition
+/multi_run.py
+/multi_run.bat
+/Bellevue_PMA1.txt

--- a/scripts/supplemental/distribute_non_work_ixxi.py
+++ b/scripts/supplemental/distribute_non_work_ixxi.py
@@ -3,7 +3,6 @@ import os
 import pandas as pd
 import h5py
 import numpy as np
-import inro.emme.matrix as ematrix
 import sys
 sys.path.append(os.path.join(os.getcwd(),"scripts"))
 sys.path.append(os.path.join(os.getcwd(),"scripts/trucks"))

--- a/scripts/supplemental/distribute_non_work_ixxi.py
+++ b/scripts/supplemental/distribute_non_work_ixxi.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 import h5py
 import numpy as np
+import inro.emme.matrix as ematrix
 import sys
 sys.path.append(os.path.join(os.getcwd(),"scripts"))
 sys.path.append(os.path.join(os.getcwd(),"scripts/trucks"))


### PR DESCRIPTION
Supplemental crashed while running updated develop branch. ematrix was undefined in distribute_non_work_ixxi.py. i reviewed the emme matrix api guide and it requires the import of inro.emme.matrix. the same line is in truck_model.py so that the code can access the matrix api. tested updated code, no crashes. 